### PR TITLE
[Feat] 게시글 목록 페이지: Category(태그 목록) 추가

### DIFF
--- a/src/main/java/com/web/app/controller/BoardController.java
+++ b/src/main/java/com/web/app/controller/BoardController.java
@@ -4,6 +4,7 @@ import com.web.app.domain.board.Board;
 import com.web.app.dto.BoardDTO;
 import com.web.app.dto.PageRequestDTO;
 import com.web.app.dto.PageResponseDTO;
+import com.web.app.dto.PageResponseWithCategoryDTO;
 import com.web.app.mediator.GetBoardListFromEmailOfJWT;
 import com.web.app.mediator.GetEmailFromJWT;
 import com.web.app.service.BoardService;
@@ -66,9 +67,9 @@ public class BoardController {
 
         String email = getEmailFromJWT.execute(request);
 
-        PageResponseDTO<BoardDTO> pageResponseDTO = boardService.readAllWithPagingAndSearch(email, pageRequestDTO);
+        PageResponseWithCategoryDTO<BoardDTO> response = boardService.readAllWithPagingAndSearch(email, pageRequestDTO);
 
-        return new ResponseEntity(pageResponseDTO, HttpStatus.OK);
+        return new ResponseEntity(response, HttpStatus.OK);
     }
 
     @PostMapping

--- a/src/main/java/com/web/app/dto/PageResponseWithCategoryDTO.java
+++ b/src/main/java/com/web/app/dto/PageResponseWithCategoryDTO.java
@@ -1,0 +1,55 @@
+package com.web.app.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@ToString
+public class PageResponseWithCategoryDTO<E> {
+
+    private int page;
+    private int size;
+    private int total;
+
+    // 시작 페이지 번호
+    private int start;
+    // 끝 페이지 번호
+    private int end;
+
+    // 이전 페이지의 존재 여부
+    private boolean prev;
+    // 다음 페이지의 존재 여부
+    private boolean next;
+
+    private List<E> dtoList;
+
+    private Map<String, Integer> dtoTags;
+
+    @Builder
+    public PageResponseWithCategoryDTO(PageRequestDTO pageRequestDTO, List<E> dtoList, int total, Map<String, Integer> dtoTags) {
+
+        this.page = pageRequestDTO.getPage();
+        this.size = pageRequestDTO.getSize();
+        this.dtoList = dtoList;
+        this.total = total;
+        this.dtoTags = dtoTags;
+
+        this.end = (int)(Math.ceil(this.page / 10.0)) * 10;
+
+        this.start = end - 9;
+
+        int last = (int)(Math.ceil(total/(double) size));
+
+        this.end = Math.min(end, last);
+
+        this.prev = this.start > 1;
+
+        this.next = total > this.end * this.size;
+
+    }
+
+}

--- a/src/main/java/com/web/app/repository/BoardRepository.java
+++ b/src/main/java/com/web/app/repository/BoardRepository.java
@@ -14,8 +14,8 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardSearch
     @Query("select b from Board b where b.email = :email")
     List<Board> findListAll(String email);
 
-    @Query("select count(b.id) from Board b")
-    int getCount();
+    @Query("select count(b.id) from Board b where b.email = :email")
+    int getCount(String email);
 
     // ** Deprecated **
     // nativeQuery 사용한 페이징 목록 조회

--- a/src/main/java/com/web/app/service/BoardService.java
+++ b/src/main/java/com/web/app/service/BoardService.java
@@ -4,6 +4,7 @@ import com.web.app.domain.board.Board;
 import com.web.app.dto.BoardDTO;
 import com.web.app.dto.PageRequestDTO;
 import com.web.app.dto.PageResponseDTO;
+import com.web.app.dto.PageResponseWithCategoryDTO;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.List;
@@ -18,10 +19,9 @@ public interface BoardService {
 
     public PageResponseDTO<BoardDTO> readAllWithPaging(String email, PageRequestDTO pageRequestDTO);
 
-    public PageResponseDTO<BoardDTO> readAllWithPagingAndSearch(String email, PageRequestDTO pageRequestDTO);
+    public PageResponseWithCategoryDTO<BoardDTO> readAllWithPagingAndSearch(String email, PageRequestDTO pageRequestDTO);
 
     public Board modify(HttpServletRequest request, Long id, BoardDTO BoardDTO);
 
     public void remove(HttpServletRequest request, Long id);
-
 }


### PR DESCRIPTION
- 기존 PageResponseDTO -> PageResponseWithCategoryDTO 로 변경
- 사용자별 게시글의 모든 태그 목록 카테고리화 (중복 불허)
- 전체 보기 -> 사용자별 게시글 총 합
- 태그별 개수 -> 해당 태그가 포함된 게시글 총 합