### PR TITLE
[FIX] buildspec.yml: net-tools lib 추가

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,6 +4,9 @@ phases:
   install:
     runtime-version:
       java: corretto17
+    commands:
+      - apt update
+      - apt install -y net-tools
   build:
     commands:
       - echo Phase/build Start


### PR DESCRIPTION
- CodeBuild 빌드 진행 시 테스트 실패 수정을 위해 buildspec.yml 수정
- 통합 테스트 진행 시 Redis 포트 충돌 회피 로직에서 netstat 라이브러리가 필요하기 때문에, install 단계에서 해당 라이브러리 설치