### PR TITLE
[FIX] buildspec.yml: aws-cli 중복 설치 과정 제거

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,9 +7,6 @@ phases:
     commands:
       - apt update
       - apt install -y net-tools
-      - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-      - unzip awscliv2.zip
-      - sudo ./aws/install
       - yum install -y docker
       - service docker start
       - aws ecr get-login-password --region $MY_REGION | docker login --username AWS --password-stdin $MY_ECR_URL
@@ -21,7 +18,7 @@ phases:
       - ./gradlew build
   post_build:
     commands:
-      - echo Post_build Startc
+      - echo Post_build Start
       - echo 'FROM openjdk:17' > Dockerfile
       - echo 'WORKDIR /app' >> Dockerfile
       - echo 'COPY ./build/libs/*-SNAPSHOT.jar app.jar' >> Dockerfile


### PR DESCRIPTION
- CodeBuild - Install 단계에서 `Found preexisting AWS CLI installation` 에러 발생으로 인한 aws-cli 중복 설치 과정 제거
- CodeBuild 는 기본적으로 aws-cli가 설치되어 있다.