### PR TITLE
[FIX] buildspec.yml: docker 설치 과정 수정

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,7 +7,7 @@ phases:
     commands:
       - apt update
       - apt install -y net-tools
-      - yum install -y docker
+      - apt install -y docker.io
       - service docker start
       - aws ecr get-login-password --region $MY_REGION | docker login --username AWS --password-stdin $MY_ECR_URL
   build:


### PR DESCRIPTION
- AWS CodeBuild에서는 Ubuntu나 Debian 기반의 이미지를 사용할 경우 `yum` 대신 `apt-get`을 사용해야 합니다.