### PR TITLE
[FIX] buildspec.yml: docker client 인증 명령어 수정

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,7 +7,7 @@ phases:
     commands:
       - apt update
       - apt install -y net-tools
-      - aws ecr get-login-password --region $MY_REGION | docker login --username AWS --password-stdin $MY_ECR_URL
+      - aws ecr-public get-login-password --region $MY_REGION | docker login --username AWS --password-stdin $MY_ECR_URL
   build:
     commands:
       - echo Phase/build Start


### PR DESCRIPTION
- private ECR 과 public ECR 에 대해 각각 도커 클라이언트 인증 명령어가 미묘하게 달랐다...
- 권한 정책을 옳게 설정해줬음에도 불구하고 계속 실패하던 원인이다.
- `AmazonElasticContainerRegistryPublicFullAccess`