### PR TITLE
[FIX] buildspec.yml: docker 데몬 명시적 실행

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,6 +7,7 @@ phases:
     commands:
       - apt update
       - apt install -y net-tools
+      - dockerd &
       - aws ecr-public get-login-password --region $MY_REGION | docker login --username AWS --password-stdin $MY_ECR_URL
   build:
     commands:


### PR DESCRIPTION
- CodeBuild는 docker가 내장되어 있지만, docker build를 하기 위해선 docker 데몬을 명시적으로 시작해줘야 한다.