### PR TITLE
[FIX] buildspec.yml: Privileged mode docker 데몬 명시적 실행

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,7 +7,8 @@ phases:
     commands:
       - apt update
       - apt install -y net-tools
-      - dockerd &
+      - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &
+      - timeout 15 sh -c "until docker info; do echo .; sleep 1; done" # Docker 데몬이 정상적으로 실행되었는지 15초 동안 확인
       - aws ecr-public get-login-password --region $MY_REGION | docker login --username AWS --password-stdin $MY_ECR_URL
   build:
     commands:


### PR DESCRIPTION
- CodeBuild에서 Dockerfile을 빌드하려면 Privileged 옵션을 활성화 시켜서 docker 데몬을 실행시켜야 한다고 한다.
- [참고](https://docs.aws.amazon.com/codebuild/latest/userguide/change-project-console.html)